### PR TITLE
feat(health): add availability-focused health endpoint and related tests

### DIFF
--- a/packages/backend/src/app/app.module.ts
+++ b/packages/backend/src/app/app.module.ts
@@ -8,16 +8,24 @@ import { BenchmarkService } from '../benchmark/benchmark.service';
 import { LtiController } from '../lti/lti.controller';
 import { LtiService } from '../lti/lti.service';
 import { XapiService } from '../xapi.service';
+import { HealthController } from '../health/health.controller';
+import { HealthService } from '../health/health.service';
 
 @Module({
   imports: [GraphModule],
-  controllers: [GraphController, BenchmarkController, LtiController],
+  controllers: [
+    GraphController,
+    BenchmarkController,
+    LtiController,
+    HealthController,
+  ],
   providers: [
     GraphService,
     PrismaService,
     BenchmarkService,
     LtiService,
     XapiService,
+    HealthService,
   ],
 })
 export class AppModule {}

--- a/packages/backend/src/health/health.controller.spec.ts
+++ b/packages/backend/src/health/health.controller.spec.ts
@@ -1,0 +1,56 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { PrismaService } from '../prisma.service';
+import { HealthController } from './health.controller';
+import { HealthService } from './health.service';
+
+describe('[HASKI-REQ-0030] HealthController', () => {
+  let app: INestApplication;
+  const prismaQueryMock = jest.fn();
+  const prismaMock = {
+    $queryRaw: prismaQueryMock,
+  } as unknown as PrismaService;
+
+  beforeEach(async () => {
+    prismaQueryMock.mockReset();
+    prismaQueryMock.mockResolvedValue([{ value: 1 }]);
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        HealthService,
+        { provide: PrismaService, useValue: prismaMock },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('[HASKI-REQ-0030] returns ok health payload when database is available', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/health')
+      .expect(200);
+
+    expect(response.body.status).toBe('ok');
+    expect(response.body.components.database.status).toBe('up');
+    expect(response.body.uptimeSeconds).toBeGreaterThanOrEqual(0);
+    expect(response.body.requirements).toContain('HASKI-REQ-0030');
+  });
+
+  it('[HASKI-REQ-0030] reports degraded state when database check fails', async () => {
+    prismaQueryMock.mockRejectedValueOnce(new Error('db down'));
+
+    const response = await request(app.getHttpServer())
+      .get('/health')
+      .expect(200);
+
+    expect(response.body.status).toBe('degraded');
+    expect(response.body.components.database.status).toBe('down');
+  });
+});

--- a/packages/backend/src/health/health.controller.ts
+++ b/packages/backend/src/health/health.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { HealthService } from './health.service';
+
+@Controller('health')
+export class HealthController {
+  constructor(private readonly healthService: HealthService) {}
+
+  @Get()
+  async getHealth() {
+    return this.healthService.check();
+  }
+}

--- a/packages/backend/src/health/health.service.ts
+++ b/packages/backend/src/health/health.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import { performance } from 'perf_hooks';
+import { PrismaService } from '../prisma.service';
+
+type ComponentStatus = 'up' | 'down';
+
+type OverallStatus = 'ok' | 'degraded';
+
+@Injectable()
+export class HealthService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async check() {
+    const startedAt = performance.now();
+
+    const dbStatus = await this.checkDatabase();
+
+    const result = {
+      status:
+        dbStatus.status === 'up'
+          ? ('ok' as OverallStatus)
+          : ('degraded' as OverallStatus),
+      service: 'nodegrade-backend',
+      timestamp: new Date().toISOString(),
+      env: process.env.NODE_ENV ?? 'development',
+      uptimeSeconds: Math.round(process.uptime()),
+      availabilityTarget: '>=99% during lecture and exam periods',
+      requirements: ['HASKI-REQ-0030'],
+      components: {
+        database: dbStatus,
+      },
+      durations: {
+        totalMs: Math.round(performance.now() - startedAt),
+      },
+    };
+
+    return result;
+  }
+
+  private async checkDatabase(): Promise<{
+    status: ComponentStatus;
+    latencyMs: number | null;
+  }> {
+    const startedAt = performance.now();
+
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return {
+        status: 'up',
+        latencyMs: Math.round(performance.now() - startedAt),
+      };
+    } catch {
+      return {
+        status: 'down',
+        latencyMs: null,
+      };
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new health check endpoint to the backend service, allowing for monitoring of application and database status. It adds a dedicated `HealthController` and `HealthService`, integrates them into the application module, and provides automated tests to verify correct behavior under normal and degraded conditions.

**Health check endpoint implementation:**

* Added `HealthController` with a `/health` GET endpoint that returns service and database health status.
* Implemented `HealthService` to check database connectivity, measure latency, and return a structured health payload including uptime, environment, and requirements.

**Integration into application module:**

* Registered `HealthController` and `HealthService` in the main `AppModule` to make the health endpoint available.

**Automated testing:**

* Added `health.controller.spec.ts` to test the health endpoint, covering both healthy and degraded (database down) scenarios.

Closes #49 